### PR TITLE
fix: Use distributor 0.18.0 for Keptn 0.18.0 compatibility

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,7 +27,7 @@ distributor:
   projectFilter: ""                          # Sets the project this helm service belongs to
   image:
     repository: "docker.io/keptn/distributor"      # Container Image Name
-    tag: "0.17.0"                                  # Container Tag
+    tag: "0.18.0"                                  # Container Tag
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
   config:
     queueGroup:


### PR DESCRIPTION
During testing I noticed that jmeter-service does not work with Keptn 0.18, and I got the following error message:
```
time="2022-08-29T09:54:22Z" level=info msg="Loading jmeter/jmeter.conf.yaml for sockshop.dev.carts"
time="2022-08-29T09:54:22Z" level=info msg="error when trying to load jmeter/jmeter.conf.yaml file for service carts on stage dev or project-level sockshop"
time="2022-08-29T09:54:22Z" level=error msg="Unable to run JMeter tests: error when trying to load jmeter/jmeter.conf.yaml file for service carts on stage dev or project-level sockshop"
```

This was most likely caused by using an old version of keptn/distributor. Updating fixes it:

![image](https://user-images.githubusercontent.com/56065213/187189209-7e8ede48-8f69-4ed5-9ab0-1fff2b945c9f.png)
